### PR TITLE
Revert wro4j version to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1020,6 +1020,6 @@
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH'\:'mm'\:'ssZ</maven.build.timestamp.format>
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <rootProjectDir>..</rootProjectDir>
-		<wro.version>1.7.5</wro.version>
+		<wro.version>1.7.1</wro.version>
   </properties>
 </project>

--- a/wro4j/pom.xml
+++ b/wro4j/pom.xml
@@ -97,6 +97,6 @@
     </profiles>
     <properties>
         <rootProjectDir>${basedir}/..</rootProjectDir>
-				<wro.version>1.7.5</wro.version>
+				<wro.version>1.7.1</wro.version>
     </properties>
 </project>


### PR DESCRIPTION
Reverted wro4j version in order to prevent maven tests failing on core-geonetwork war build
