### PR TITLE
Fix previous concept mix and basic language support

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/thesaurus/GetTopConcept.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/GetTopConcept.java
@@ -70,13 +70,13 @@ public class GetTopConcept implements Service {
 			
 				KeywordBean topConcept = new KeywordBean(the.getIsoLanguageMapper());
 				topConcept.setThesaurusInfo(the);
-				topConcept.setValue("Top Concept(s)", langForThesaurus);
+				topConcept.setValue("topConcepts", langForThesaurus);
 				topConcept.setUriCode(sThesaurusName);
         Element root = KeywordsSearcher.toRawElement(new Element("descKeys"), topConcept);
 
 				Element keywordType = new Element("narrower");
 				for (KeywordBean kbr : searcher.getResults()) {
-					keywordType.addContent(kbr.toElement(context.getLanguage()));
+					keywordType.addContent(kbr.toElement("eng", context.getLanguage()));
 				}
 				root.addContent(keywordType);
         

--- a/web-ui/src/main/resources/catalog/components/ng-skos/ngSkosBrowserDirective.js
+++ b/web-ui/src/main/resources/catalog/components/ng-skos/ngSkosBrowserDirective.js
@@ -63,8 +63,6 @@
       ['$compile', 'gnThesaurusService',
        function($compile, gnThesaurusService) {
 
-         var previous = [];
-
          return {
            restrict: 'E',
            replace: true,
@@ -75,17 +73,14 @@
            templateUrl: '../../catalog/components/ng-skos/' +
            'templates/skos-browser.html',
            link: function link(scope, element, attr) {
-
-             $compile(element.contents())(scope); // pick up skos concept
-             // directive with compiler
-
+             scope.previous = [];
              angular.forEach(['URI', 'Notation', 'Label'], function(value) {
                 var lookup = gnThesaurusService['lookup' + value];
                 if (lookup) {
                  scope['select' + value] = function(thes, query) {
                    lookup(thes, query).then(
                    function(response) {
-                     if (previous) response.previous = previous;
+                     if (scope.previous) response.previous = scope.previous;
                      angular.copy(response, scope.concept);
                    }
                    );
@@ -95,7 +90,7 @@
 
              // Select concept for navigation, push previous concept onto stack
              scope.selectConcept = function(concept, previousConcept) {
-                if (!previousConcept) previous.unshift(concept);
+                if (!previousConcept) scope.previous.unshift(concept);
                 if (scope.selectURI && concept.uri) {
                  scope.selectURI(concept.thesaurus, concept.uri);
                 } else if (scope.selectNotation && concept.notation &&

--- a/web-ui/src/main/resources/catalog/components/ng-skos/ngSkosBrowserDirective.js
+++ b/web-ui/src/main/resources/catalog/components/ng-skos/ngSkosBrowserDirective.js
@@ -67,8 +67,9 @@
            restrict: 'E',
            replace: true,
            scope: {
-             concept: '=concept',
-             addConcept: '=addConcept'
+             concept: '=',
+             language: '=',
+             addConcept: '='
            },
            templateUrl: '../../catalog/components/ng-skos/' +
            'templates/skos-browser.html',

--- a/web-ui/src/main/resources/catalog/components/ng-skos/ngSkosConceptDirective.js
+++ b/web-ui/src/main/resources/catalog/components/ng-skos/ngSkosConceptDirective.js
@@ -65,20 +65,23 @@
            restrict: 'AE',
            scope: {
              concept: '=skosConcept',
-             language: '=language',
+             language: '=',
              navigateConcept: '=skosNavigateConcept',
-             addConcept: '=skosAddConcept',
+             addConceptToList: '=skosAddConcept',
              topConcept: '=skosTopConcept'
            },
            templateUrl: '../../catalog/components/ng-skos/' +
            'templates/skos-concept.html',
            link: function link(scope, element, attr) {
-             $compile(element.contents())(scope); // pick up skos label
-             // directive with compiler
-
+              scope.mainLanguage = scope.language.split(',')[0];
              scope.isEmptyObject = function(object) {
                 var keys = Object.keys;
                 return !(keys && keys.length);
+             };
+             scope.addConcept = function(c) {
+               var label = c.prefLabel[scope.mainLanguage] ||
+                           c.prefLabel[Object.keys(c.prefLabel)[0]];
+               scope.addConceptToList(c.uri, label);
              };
              scope.$watch('concept', function(concept) {
                 angular.forEach([

--- a/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-browser.html
+++ b/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-browser.html
@@ -1,3 +1,5 @@
 <div class="col-sm-12" ng-show="concept">
-	<div skos-concept="concept" skos-navigate-concept="selectConcept" skos-add-concept="addConcept" skos-top-concept="topConcept" language="language"></div>
+  <div skos-concept="concept" skos-navigate-concept="selectConcept" 
+       skos-add-concept="addConcept" skos-top-concept="topConcept" 
+       language="language"></div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-concept.html
+++ b/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-concept.html
@@ -1,25 +1,25 @@
 <div class="skos-concept">
     <div class="top top-alt">
-			<div class="row vcentre">
-				<div class="col-sm-7">
-					<b>
-        	<span ng-if="prefLabel" skos-label="concept" lang="{{language}}"></span>
-					</b>
-				</div>
-				<div ng-if="concept.previous" class="col-sm-3"> 
-					<button class="btn-small btn-default dropdown-toggle" type="button" id="previous" data-toggle="dropdown">Previous <span class="caret"></span></button>
-					<ul class="dropdown-menu" role="menu" aria-labelledby="previous">
-        		<li role="presentation" ng-repeat="c in concept.previous">
-							<div class="skos-concept-relation-previous dropdown">
-            		<span role="menuitem" tabindex="-1" skos-label="c" ng-click="navigateConcept(c, true)" lang="{{language}}"></span>
-							</div>
-        		</li>
-					</ul>
-				</div>
-				<div ng-if="concept.previous" class="col-sm-2 skos-concept-relation">
-					<i class="fa fa-refresh pull-right" ng-click="topConcept(concept.thesaurus)"/></i>
-				</div>
-			</div>
+      <div class="row vcentre">
+        <div class="col-sm-7">
+          <b>
+          <span ng-if="prefLabel" skos-label="concept" lang="{{language}}"></span>
+          </b>
+        </div>
+        <div ng-if="concept.previous" class="col-sm-3"> 
+          <button class="btn-small btn-default dropdown-toggle" type="button" id="previous" data-toggle="dropdown"><span data-translate="">previousKeywords</span><span class="caret"></span></button>
+          <ul class="dropdown-menu" role="menu" aria-labelledby="previous">
+            <li role="presentation" ng-repeat="c in concept.previous">
+              <div class="skos-concept-relation-previous dropdown">
+                <span role="menuitem" tabindex="-1" skos-label="c" ng-click="navigateConcept(c, true)" lang="{{language}}"></span>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div ng-if="concept.previous" class="col-sm-2 skos-concept-relation">
+          <i class="fa fa-refresh pull-right" ng-click="topConcept(concept.thesaurus)"/></i>
+        </div>
+      </div>
     </div>
     <!-- TODO: use language, too -->
     <div ng-if="altLabel.length" class="skos-concept-altlabel">
@@ -34,29 +34,32 @@
         <div ng-if="broader.length">
             <ul ng-repeat="c in broader">
                 <li>
-									<div class="skos-concept-relation">
+                  <div class="skos-concept-relation">
                     <i class="fa fa-long-arrow-up" ng-click="navigateConcept(c)"></i>
-										<span skos-label="c" lang="{{language}}" ng-click="addConcept(c)" title="{{c.notation[0]}}"></span>
-									</div>
+                    <span skos-label="c" lang="{{mainLanguage}}"
+                          ng-click="addConcept(c)" title="{{c.notation[0]}}"></span>
+                  </div>
                 </li>
             </ul>
         </div>
         <div ng-if="narrower.length">
             <ul ng-repeat="c in narrower">
                 <li>
-									<div class="skos-concept-relation">
-										<i class="fa fa-long-arrow-down" ng-click="navigateConcept(c)"></i>
-										<span skos-label="c" lang="{{language}}" ng-click="addConcept(c.uri, c.prefLabel.en)" title="{{c.notation[0]}}"></span>
-									</div>
+                  <div class="skos-concept-relation">
+                    <i class="fa fa-long-arrow-down" ng-click="navigateConcept(c)"></i>
+                    <span skos-label="c" lang="{{mainLanguage}}"
+                          ng-click="addConcept(c)" title="{{c.notation[0]}}"></span>
+                  </div>
                 </li>
             </ul>
         </div>
         <div ng-if="related.length">
             <ul ng-repeat="c in related">
                 <li>
-									<div class="skos-concept-relation">
-										<i class="fa fa-long-arrow-right" ng-click="navigateConcept(c)"></i>
-                    <span skos-label="c" lang="{{language}}" ng-click="addConcept(c)" title="{{c.notation[0]}}"></span>
+                  <div class="skos-concept-relation">
+                    <i class="fa fa-long-arrow-right" ng-click="navigateConcept(c)"></i>
+                    <span skos-label="c" lang="{{mainLanguage}}"
+                          ng-click="addConcept(c)" title="{{c.notation[0]}}"></span>
                 </li>
             </ul>
         </div>

--- a/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
@@ -65,7 +65,7 @@
 
 		<div class="row" ng-show="concept">
       <div class="col-sm-9 col-md-offset-2">
-        <skos-browser class="tmpl-border" concept="concept" add-concept="addThesaurusConcept"></skos-browser> 
+        <skos-browser class="tmpl-border" concept="concept" add-concept="addThesaurusConcept" language="langs"></skos-browser>
       </div>
     </div>
     

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -23,6 +23,8 @@
     "_groupPublished": "Published in that group",
     "_indexingError": "Indexing error",
     "_source": "Catalog",
+    "previousKeywords": "Previous",
+    "topConcepts": "Top Concept(s)",
     "add": "Add",
     "address": "Address",
     "cookieWarning": "This webpage uses cookies. If you continue navigating this page, we will assume you accept this.",

--- a/web/src/main/webapp/xslt/services/thesaurus/to-jskos.xsl
+++ b/web/src/main/webapp/xslt/services/thesaurus/to-jskos.xsl
@@ -10,16 +10,19 @@
 			<null></null>
 		</xsl:param>
 
+		<xsl:variable name="iso3code" select="//descKeys/keyword[1]/defaultLang"/>
 		<keyword>
 			<xsl:variable name="contents">
 				<xsl:copy-of select="uri"/>
 				<prefLabel>
-					<en>
-						<xsl:value-of select="value[@language='eng' or @lang='EN']/text()"/>
-					</en>
-					<eng>
-						<xsl:value-of select="value[@language='eng' or @lang='EN']/text()"/>
-					</eng>
+					<xsl:for-each select="value">
+						<xsl:element name="{$iso3code}">
+							<xsl:value-of select="text()"/>
+						</xsl:element>
+						<xsl:element name="{lower-case(substring(@lang|@language, 1, 2))}">
+							<xsl:value-of select="text()"/>
+						</xsl:element>
+					</xsl:for-each>
 				</prefLabel>
 				<thesaurus>
 					<xsl:value-of select="//request/thesaurus"/>


### PR DESCRIPTION
- Do not mix previous concept between directive. Move the previous var to the scope.
- Also not sure why the $compile was used for. Looks to be working fine without it. To check before merge.
- Add basic language support when switching GUI language
